### PR TITLE
Delete symlink for .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,1 +1,0 @@
-/Users/szczesniak/jon/github/dotfiles/zshrc


### PR DESCRIPTION
Didn't remember how I had the .git setup on the iMac. I inadvertently added the symlink to the repo.
